### PR TITLE
Remove references to the old FIWARE Store and improve plugin metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,32 @@
-CKAN Store Publisher [![Build Status](https://travis-ci.org/FIWARE-TMForum/ckanext-baepublisher.svg?branch=master)](https://travis-ci.org/FIWARE-TMForum/ckanext-baepublisher) [![Coverage Status](https://coveralls.io/repos/github/FIWARE-TMForum/ckanext-baepublisher/badge.svg?branch=master)](https://coveralls.io/github/FIWARE-TMForum/ckanext-baepublisher?branch=master)
-=====================
+CKAN BAE Publisher
+==================
 
-CKAN extension that allows users to publish datasets in the FIWARE Store (Business API Ecosystem GE) as offerings in a simpler way. To do so, a new tab is added in the Datasets *Manage* menu that offers a form to set the basic options of the offering.
+[![Build Status](https://travis-ci.org/FIWARE-TMForum/ckanext-baepublisher.svg?branch=master)](https://travis-ci.org/FIWARE-TMForum/ckanext-baepublisher)
+[![Coverage Status](https://coveralls.io/repos/github/FIWARE-TMForum/ckanext-baepublisher/badge.svg?branch=master)](https://coveralls.io/github/FIWARE-TMForum/ckanext-baepublisher?branch=master)
 
-Offerings are **not** automatically published so the dataset creator must access this form and complete it in order to publish the dataset in the FIWARE Store.
+CKAN extension that allows users to publish datasets in the FIWARE Business API Ecosystem GE as offerings in an easy way. To do so, a new tab is added in the Datasets *Manage* menu that offers a form to set the basic options of the offering.
 
-**Note:** This software is intended to integrate a CKAN instance with the FIWARE Store so it won't probably work with other Stores.
+Offerings are **not** automatically published so the dataset creator must access this form and complete it in order to publish the dataset using the FIWARE Business API Ecosystem.
+
+**Note:** This software is intended to integrate a CKAN instance with the FIWARE Business API Ecosystem and it won't work with other Marketplaces/Stores.
 
 Requirements
 ------------
 
-* A CKAN instance able to connect to the FIWARE Store via HTTP(s)
-* [FIWARE/TMF Biz Ecosystem v5.4.0 or higher](https://github.com/FIWARE-TMForum/Business-API-Ecosystem)
-* [OAuth2 CKAN Extension](https://github.com/conwetlab/ckanext-oauth2/). This extension is needed since the requests sent to the Store must include the OAuth2 credentials to identify the user that is creating the offering.
-* Optional: [CKAN Private Dataset Extension](https://github.com/conwetlab/ckanext-privatedatasets/)
+* A CKAN instance able to connect to the FIWARE Business API Ecosystem via HTTP(s)
+* [FIWARE/TMF Business API Ecosystem v5.4.0 or higher](https://github.com/FIWARE-TMForum/Business-API-Ecosystem)
+* [OAuth2 CKAN Extension](https://github.com/conwetlab/ckanext-oauth2/). This extension is needed since the requests sent to the BAE must include the OAuth2 credentials to identify the user that is creating the offering.
+* [CKAN Private Dataset Extension](https://github.com/conwetlab/ckanext-privatedatasets/)
 
 
 Installation
 ------------
 Install this extension in your CKAN instance is as easy as intall any other CKAN extension.
 
-* Download the source from this GitHub repo.
 * Activate your virtual environment (generally by running `. /usr/lib/ckan/default/bin/activate`)
-* Install the extension by running `python setup.py install`
+* Install the extension by running `pip install ckanext-baepublisher`
 * Modify your configuration file (generally in `/etc/ckan/default/production.ini`) and add `baepublisher` in the `ckan.plugins` setting. 
-* In the same config file, specify the location of FIWARE Store by adding the `ckan.baepublisher.store_url` setting.
+* In the same config file, specify the location of FIWARE BAE to use by adding the `ckan.baepublisher.store_url` setting.
 * Restart your apache2 reserver (`sudo service apache2 restart`)
 * That's All!
 

--- a/ckanext/__init__.py
+++ b/ckanext/__init__.py
@@ -2,20 +2,20 @@
 
 # Copyright (c) 2014 CoNWeT Lab., Universidad Politécnica de Madrid
 
-# This file is part of CKAN Store Publisher Extension.
+# This file is part of CKAN BAE Publisher Extension.
 
-# CKAN Store Publisher Extension is free software: you can redistribute it and/or
+# CKAN BAE Publisher Extension is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-# CKAN Store Publisher Extension is distributed in the hope that it will be useful,
+# CKAN BAE Publisher Extension is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with CKAN Store Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
+# along with CKAN BAE Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
 
 # this is a namespace package
 try:

--- a/ckanext/baepublisher/__init__.py
+++ b/ckanext/baepublisher/__init__.py
@@ -2,20 +2,20 @@
 
 # Copyright (c) 2014 CoNWeT Lab., Universidad Politécnica de Madrid
 
-# This file is part of CKAN Store Updater Extension.
+# This file is part of CKAN BAE Updater Extension.
 
-# CKAN Store Updater Extension is free software: you can redistribute it and/or
+# CKAN BAE Updater Extension is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-# CKAN Store Updater Extension is distributed in the hope that it will be useful,
+# CKAN BAE Updater Extension is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with CKAN Store Updater Extension.  If not, see <http://www.gnu.org/licenses/>.
+# along with CKAN BAE Updater Extension.  If not, see <http://www.gnu.org/licenses/>.
 
 # this is a namespace package
 try:

--- a/ckanext/baepublisher/controllers/ui_controller.py
+++ b/ckanext/baepublisher/controllers/ui_controller.py
@@ -2,20 +2,20 @@
 
 # Copyright (c) 2014-2017 CoNWeT Lab., Universidad Politécnica de Madrid
 
-# This file is part of CKAN Store Publisher Extension.
+# This file is part of CKAN BAE Publisher Extension.
 
-# CKAN Store Publisher Extension is free software: you can redistribute it and/or
+# CKAN BAE Publisher Extension is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-# CKAN Store Publisher Extension is distributed in the hope that it will be useful,
+# CKAN BAE Publisher Extension is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with CKAN Store Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
+# along with CKAN BAE Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/ckanext/baepublisher/fanstatic/image_upload.js
+++ b/ckanext/baepublisher/fanstatic/image_upload.js
@@ -1,20 +1,20 @@
 /*
  * (C) Copyright 2014 CoNWeT Lab., Universidad Politécnica de Madrid
  *
- * This file is part of CKAN Store Publisher Extension.
+ * This file is part of CKAN BAE Publisher Extension.
  *
- * CKAN Store Publisher Extension is free software: you can redistribute it and/or
+ * CKAN BAE Publisher Extension is free software: you can redistribute it and/or
  * modify it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
  *
- * CKAN Store Publisher Extension is distributed in the hope that it will be useful, but
+ * CKAN BAE Publisher Extension is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
  * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
  * License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with CKAN Store Publisher Extension. If not, see
+ * along with CKAN BAE Publisher Extension. If not, see
  * <http://www.gnu.org/licenses/>.
  *
  */

--- a/ckanext/baepublisher/plugin.py
+++ b/ckanext/baepublisher/plugin.py
@@ -2,20 +2,20 @@
 
 # Copyright (c) 2014 - 2017 CoNWeT Lab., Universidad Politécnica de Madrid
 
-# This file is part of CKAN Store Publisher Extension.
+# This file is part of CKAN BAE Publisher Extension.
 
-# CKAN Store Publisher Extension is free software: you can redistribute it and/or
+# CKAN BAE Publisher Extension is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-# CKAN Store Publisher Extension is distributed in the hope that it will be useful,
+# CKAN BAE Publisher Extension is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with CKAN Store Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
+# along with CKAN BAE Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
 
 import ckan.plugins as plugins
 

--- a/ckanext/baepublisher/store_connector.py
+++ b/ckanext/baepublisher/store_connector.py
@@ -2,19 +2,19 @@
 
 # Copyright (c) 2015 CoNWeT Lab., Universidad Politécnica de Madrid
 
-# This file is part of CKAN Store Publisher Extension.
+# This file is part of CKAN BAE Publisher Extension.
 
-# CKAN Store Publisher Extension is free software: you can redistribute it and/or
+# CKAN BAE Publisher Extension is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# CKAN Store Publisher Extension is distributed in the hope that it will be useful,
+# CKAN BAE Publisher Extension is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with CKAN Store Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
+# along with CKAN BAE Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/ckanext/baepublisher/tests/test_plugin.py
+++ b/ckanext/baepublisher/tests/test_plugin.py
@@ -2,20 +2,20 @@
 
 # Copyright (c) 2014 - 2017 CoNWeT Lab., Universidad Politécnica de Madrid
 
-# This file is part of CKAN Store Publisher Extension.
+# This file is part of CKAN BAE Publisher Extension.
 
-# CKAN Store Publisher Extension is free software: you can redistribute it and/or
+# CKAN BAE Publisher Extension is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-# CKAN Store Publisher Extension is distributed in the hope that it will be useful,
+# CKAN BAE Publisher Extension is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with CKAN Store Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
+# along with CKAN BAE Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
 
 import ckanext.baepublisher.plugin as plugin
 

--- a/ckanext/baepublisher/tests/test_store_connector.py
+++ b/ckanext/baepublisher/tests/test_store_connector.py
@@ -2,20 +2,20 @@
 
 # Copyright (C) 2015 - 2018 Conwet Lab., Universidad Politécnica de Madrid
 
-# This file is part of CKAN Store Publisher Extension.
+# This file is part of CKAN BAE Publisher Extension.
 
-# CKAN Store Publisher Extension is free software: you can redistribute it and/or
+# CKAN BAE Publisher Extension is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-# CKAN Store Publisher Extension is distributed in the hope that it will be useful,
+# CKAN BAE Publisher Extension is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with CKAN Store Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
+# along with CKAN BAE Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 import ckanext.baepublisher.store_connector as store_connector

--- a/ckanext/baepublisher/tests/test_ui_controller.py
+++ b/ckanext/baepublisher/tests/test_ui_controller.py
@@ -2,20 +2,20 @@
 
 # Copyright (c) 2014 - 2018 CoNWeT Lab., Universidad Politécnica de Madrid
 
-# This file is part of CKAN Store Publisher Extension.
+# This file is part of CKAN BAE Publisher Extension.
 
-# CKAN Store Publisher Extension is free software: you can redistribute it and/or
+# CKAN BAE Publisher Extension is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-# CKAN Store Publisher Extension is distributed in the hope that it will be useful,
+# CKAN BAE Publisher Extension is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with CKAN Store Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
+# along with CKAN BAE Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 import ckanext.baepublisher.controllers.ui_controller as controller

--- a/setup.py
+++ b/setup.py
@@ -2,47 +2,58 @@
 
 # Copyright (c) 2014 - 2017 CoNWeT Lab., Universidad Politécnica de Madrid
 
-# This file is part of CKAN Store Publisher Extension.
+# This file is part of CKAN BAE Publisher Extension.
 
-# CKAN Store Publisher Extension is free software: you can redistribute it and/or
+# CKAN BAE Publisher Extension is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-# CKAN Store Publisher Extension is distributed in the hope that it will be useful,
+# CKAN BAE Publisher Extension is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
 # You should have received a copy of the GNU Affero General Public License
-# along with CKAN Store Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
+# along with CKAN BAE Publisher Extension.  If not, see <http://www.gnu.org/licenses/>.
 
 from setuptools import setup, find_packages
+import os
+
 
 version = '0.4'
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
     name='ckanext-baepublisher',
     version=version,
-    description="CKAN extension that allows users to publish datasets in the FIWARE Store (as offerings) in a simpler way. To do so, a new tab is added in the Datasets Manage menu that offers a form to set the basic options of the offering.",
-    long_description='''
-    ''',
-    classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-    keywords='',
+    description="CKAN extension allowing users to publish datasets in the FIWARE Business API Ecosystem as offerings in an easy way.",
+    long_description=read('README.md'),
+    long_description_content_type="text/markdown",
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+    ],
+    keywords='CKAN FIWARE BAE TM Forum Business API Ecosystem monetization',
     author='Aitor Magan, Francisco de la Vega',
     author_email='fdelavega@conwet.com',
-    url='',
-    license='',
+    url='https://github.com/FIWARE-TMForum/ckanext-baepublisher',
+    license='AGPLv3+',
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     namespace_packages=['ckanext', 'ckanext.baepublisher'],
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'ckanext-oauth2'
+        'ckanext-oauth2>=0.4.0',
+        'ckanext-privatedatasets>=0.4',
     ],
     entry_points='''
         [ckan.plugins]
-        # Add plugins here, e.g.
         baepublisher=ckanext.baepublisher.plugin:StorePublisher
     ''',
 )


### PR DESCRIPTION
This PR updates the plugin name on the copyright headers. This PR also improves the metadata used on the `setup.py` file.